### PR TITLE
竖屏再适配 & 修复图片位置bug

### DIFF
--- a/EH_VIEW_PLUS.js
+++ b/EH_VIEW_PLUS.js
@@ -623,6 +623,7 @@ const updateEvent = function (k, v) {
         bigImageFrame.addEventListener("mousemove", followMouseEvent);
       } else {
         bigImageFrame.removeEventListener("mousemove", followMouseEvent);
+        bigImageElement.style.left = "";
       }
       break;
     }

--- a/EH_VIEW_PLUS.js
+++ b/EH_VIEW_PLUS.js
@@ -241,7 +241,8 @@ class IMGFetcherQueue extends Array {
     if (index !== this.currIndex) return;
     if (!conf.keepScale) {
       //是否保留缩放
-      bigImageElement.style.height = "";
+      bigImageElement.style.width = "100%";
+      bigImageElement.style.height = "100%";
       bigImageElement.style.top = "0px";
     }
     // bigImageElement.classList.remove("fetching");
@@ -801,6 +802,7 @@ const scaleImageEvent = function (event) {
   }
   if (parseInt(height) < 100 || parseInt(height) > 200) return;
   bigImageElement.style.height = height;
+  bigImageElement.style.width = height;
   //最后对图片top进行修正
   fixImageTop(event.clientY, true);
 };
@@ -1178,6 +1180,8 @@ styleSheel.textContent = `
   transition:width .4s
  }
  .bigImageFrame>img {
+  width: 100%;
+  height:100%;
   object-fit: contain;
   position:relative
  }


### PR DESCRIPTION
- (#8) 指定图片`width`和`height`使`object-fit: contain`真正生效
（另：由于真正生效，加载中时缩略图大小回到以前那么大了）
- 修复使用大图跟随鼠标后又关闭此功能造成的残余图片`left`